### PR TITLE
Update Rtest.py

### DIFF
--- a/arcscripts/Rtest.py
+++ b/arcscripts/Rtest.py
@@ -30,7 +30,7 @@ stdout,stderr = process.communicate()
 
 def output(x):
     for line in x.split("\n"):
-        arcpy.AddMessage(x)
+        arcpy.AddMessage(line)
 
 output(stdout)
 output(stderr)


### PR DESCRIPTION
Is this a simple mistake in a loop that is intended to write each line to arcpy.AddMessage, not the entirety of the function's argument x to arcpy multiple times, for each separate line in x? Other examples in the code base show arcpy.AddMessage acting on single line strings.